### PR TITLE
Add Errbit (Airbrake-compatible) error tracking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,3 +59,10 @@ UITDB_SEARCH_API_KEY=
 QUIZWITZ_REPORT_CLIENT_KEY=
 
 GOOGLE_MAPS_API_KEY=
+
+# Errbit (Airbrake-compatible) error tracking.
+# Reporting is enabled automatically when APP_ENV=production;
+# set ERRBIT_ENABLED=true/false to override.
+ERRBIT_HOST=
+ERRBIT_PROJECT_ID=1
+ERRBIT_PROJECT_KEY=

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -59,7 +59,33 @@ class Handler extends ExceptionHandler
      */
     public function report(Throwable $exception)
     {
+        if ($this->shouldReport($exception)) {
+            $this->notifyErrbit($exception);
+        }
+
         parent::report($exception);
+    }
+
+    /**
+     * Send an exception to Errbit, if configured.
+     *
+     * @param \Throwable $exception
+     * @return void
+     */
+    protected function notifyErrbit(Throwable $exception)
+    {
+        if (
+            !config('services.errbit.enabled') ||
+            !config('services.errbit.project_key')
+        ) {
+            return;
+        }
+
+        try {
+            app(\Airbrake\Notifier::class)->notify($exception);
+        } catch (Throwable $e) {
+            // Errbit being unreachable should never break error handling.
+        }
     }
 
     /**

--- a/app/Http/Controllers/ReferenceController.php
+++ b/app/Http/Controllers/ReferenceController.php
@@ -47,7 +47,12 @@ class ReferenceController
      */
     public static function getReferences()
     {
-        if (!\Schema::hasTable('series')) {
+        try {
+            if (!\Schema::hasTable('series')) {
+                return [];
+            }
+        } catch (\Exception $e) {
+            // No database available (e.g. while running tests without a db).
             return [];
         }
 

--- a/app/Models/Organisation.php
+++ b/app/Models/Organisation.php
@@ -53,7 +53,7 @@ class Organisation extends Model
         static $representedOrganisation;
 
         if (!isset($representedOrganisation)) {
-            $representedOrganisation = self::getFromDomainOrFirst($_SERVER['HTTP_HOST']);
+            $representedOrganisation = self::getFromDomainOrFirst($_SERVER['HTTP_HOST'] ?? '');
         }
 
         return $representedOrganisation;

--- a/app/Providers/ErrbitServiceProvider.php
+++ b/app/Providers/ErrbitServiceProvider.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * CatLab Events - Event ticketing system
+ * Copyright (C) 2017 Thijs Van der Schaeghe
+ * CatLab Interactive bvba, Gent, Belgium
+ * http://www.catlab.eu/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace App\Providers;
+
+use Airbrake\Notifier;
+use Illuminate\Support\ServiceProvider;
+
+/**
+ * Class ErrbitServiceProvider
+ *
+ * Registers the Airbrake notifier used to report exceptions to Errbit.
+ *
+ * @package App\Providers
+ */
+class ErrbitServiceProvider extends ServiceProvider
+{
+    /**
+     * Register services.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        $this->app->singleton(Notifier::class, function ($app) {
+            $config = $app['config']['services.errbit'];
+
+            return new Notifier([
+                'host' => $config['host'],
+                'projectId' => (int) $config['project_id'],
+                'projectKey' => $config['project_key'],
+                'environment' => $app->environment(),
+                'rootDirectory' => base_path(),
+
+                // Don't phone home to airbrake.io for configuration;
+                // we're talking to our own Errbit instance.
+                'remoteConfig' => false
+            ]);
+        });
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
         "php": ">=8.0",
         "ext-json": "*",
         "ext-simplexml": "*",
+        "airbrake/phpbrake": "^1.0",
         "barryvdh/laravel-debugbar": "^3.2",
         "barryvdh/laravel-dompdf": "^1.0.0",
         "catlabinteractive/central-storage-client": "~1.0.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,70 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "354e5b4dfda3ccb8d2a76823355622fb",
+    "content-hash": "c6f914964f07b4b6a74c638b91d943f4",
     "packages": [
+        {
+            "name": "airbrake/phpbrake",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/airbrake/phpbrake.git",
+                "reference": "c5c354934fa879a70e0e6167f7269fe39935beca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/airbrake/phpbrake/zipball/c5c354934fa879a70e0e6167f7269fe39935beca",
+                "reference": "c5c354934fa879a70e0e6167f7269fe39935beca",
+                "shasum": ""
+            },
+            "require": {
+                "cash/lrucache": "^1.0",
+                "guzzlehttp/guzzle": ">=6.3",
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "mikey179/vfsstream": "^1.6",
+                "monolog/monolog": "^1.22|^2.0",
+                "phpunit/phpunit": "^10.0",
+                "psy/psysh": "^0.11",
+                "squizlabs/php_codesniffer": "^3.7"
+            },
+            "suggest": {
+                "guzzlehttp/guzzle": "Guzzle HTTP client"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/constants.php"
+                ],
+                "psr-4": {
+                    "Airbrake\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Airbrake exception and error notifier for PHP",
+            "homepage": "https://airbrake.io",
+            "keywords": [
+                "airbrake",
+                "error",
+                "exception",
+                "logging",
+                "notifier"
+            ],
+            "support": {
+                "issues": "https://github.com/airbrake/phpbrake/issues",
+                "source": "https://github.com/airbrake/phpbrake/tree/v1.0.0"
+            },
+            "time": "2023-12-07T00:39:40+00:00"
+        },
         {
             "name": "barryvdh/laravel-debugbar",
             "version": "v3.13.5",
@@ -289,6 +351,51 @@
                 }
             ],
             "time": "2023-10-01T12:35:29+00:00"
+        },
+        {
+            "name": "cash/lrucache",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cash/LRUCache.git",
+                "reference": "4fa4c6834cec59690b43526c4da41d6153026289"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cash/LRUCache/zipball/4fa4c6834cec59690b43526c4da41d6153026289",
+                "reference": "4fa4c6834cec59690b43526c4da41d6153026289",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "cash": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Cash Costello",
+                    "email": "cash.costello@gmail.com"
+                }
+            ],
+            "description": "An efficient memory-based Least Recently Used (LRU) cache",
+            "homepage": "https://github.com/cash/LRUCache",
+            "keywords": [
+                "cache",
+                "lru"
+            ],
+            "support": {
+                "issues": "https://github.com/cash/LRUCache/issues",
+                "source": "https://github.com/cash/LRUCache/tree/1.0.0"
+            },
+            "time": "2013-09-20T18:59:12+00:00"
         },
         {
             "name": "catlabinteractive/base",
@@ -8830,6 +8937,6 @@
         "ext-json": "*",
         "ext-simplexml": "*"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
 }

--- a/config/app.php
+++ b/config/app.php
@@ -189,6 +189,7 @@ return [
          */
         App\Providers\AppServiceProvider::class,
         App\Providers\AuthServiceProvider::class,
+        App\Providers\ErrbitServiceProvider::class,
         // App\Providers\BroadcastServiceProvider::class,
         App\Providers\EventServiceProvider::class,
         App\Providers\RouteServiceProvider::class,

--- a/config/services.php
+++ b/config/services.php
@@ -67,6 +67,13 @@ return [
 
     'google' => [
         'maps_api_key' => env('GOOGLE_MAPS_API_KEY')
+    ],
+
+    'errbit' => [
+        'enabled' => env('ERRBIT_ENABLED', env('APP_ENV') === 'production'),
+        'host' => env('ERRBIT_HOST'),
+        'project_id' => env('ERRBIT_PROJECT_ID', 1),
+        'project_key' => env('ERRBIT_PROJECT_KEY')
     ]
 
 ];

--- a/docs/superpowers/specs/2026-07-24-errbit-error-tracking-design.md
+++ b/docs/superpowers/specs/2026-07-24-errbit-error-tracking-design.md
@@ -1,0 +1,36 @@
+# Errbit error tracking
+
+**Date:** 2026-07-24
+**Status:** Implemented
+
+## Goal
+
+Report unhandled exceptions to the self-hosted Errbit instance at
+https://errors.catlab.eu using the Airbrake v3 notice API.
+
+## Approach
+
+Use the official `airbrake/phpbrake` package (chosen over a hand-rolled
+notifier for its battle-tested backtrace formatting and filter support).
+
+## Components
+
+- **`config/services.php` → `errbit`** — `host`, `project_id`, `project_key`
+  from `ERRBIT_*` env vars. `enabled` defaults to `APP_ENV === 'production'`
+  and can be overridden with `ERRBIT_ENABLED`. The project key lives only in
+  the server's `.env`, never in the repo.
+- **`App\Providers\ErrbitServiceProvider`** — registers `Airbrake\Notifier`
+  as a lazy singleton. `remoteConfig` is disabled: phpbrake would otherwise
+  fetch its configuration from airbrake.io, which fails for an Errbit host
+  and silently disables all notifications.
+- **`App\Exceptions\Handler::report()`** — sends the exception to Errbit when
+  reporting is enabled and the exception passes `shouldReport()` (the
+  existing `$dontReport` list is respected). Notifier failures are swallowed:
+  Errbit being unreachable must never break error handling itself.
+
+## Testing
+
+`tests/Unit/Errbit/ErrbitReportingTest` covers: reported exceptions reach the
+notifier, `$dontReport` exceptions don't, nothing is sent when disabled,
+notifier failures don't propagate, and the notifier resolves from config.
+A live smoke test against errors.catlab.eu was accepted (notice id returned).

--- a/tests/Unit/Errbit/ErrbitReportingTest.php
+++ b/tests/Unit/Errbit/ErrbitReportingTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Unit\Errbit;
+
+use Airbrake\Notifier;
+use Illuminate\Contracts\Debug\ExceptionHandler;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Tests\TestCase;
+
+class ErrbitReportingTest extends TestCase
+{
+    protected function enableErrbit()
+    {
+        config([
+            'services.errbit.enabled' => true,
+            'services.errbit.host' => 'https://errors.example.com',
+            'services.errbit.project_id' => 1,
+            'services.errbit.project_key' => 'test-key',
+        ]);
+    }
+
+    public function testReportedExceptionIsSentToErrbit()
+    {
+        $this->enableErrbit();
+
+        $notifier = $this->createMock(Notifier::class);
+        $notifier->expects($this->once())->method('notify');
+        $this->app->instance(Notifier::class, $notifier);
+
+        $this->app->make(ExceptionHandler::class)->report(new \RuntimeException('boom'));
+    }
+
+    public function testIgnoredExceptionsAreNotSent()
+    {
+        $this->enableErrbit();
+
+        $notifier = $this->createMock(Notifier::class);
+        $notifier->expects($this->never())->method('notify');
+        $this->app->instance(Notifier::class, $notifier);
+
+        $this->app->make(ExceptionHandler::class)->report(new NotFoundHttpException());
+    }
+
+    public function testNothingIsSentWhenDisabled()
+    {
+        config([
+            'services.errbit.enabled' => false,
+            'services.errbit.project_key' => 'test-key',
+        ]);
+
+        $notifier = $this->createMock(Notifier::class);
+        $notifier->expects($this->never())->method('notify');
+        $this->app->instance(Notifier::class, $notifier);
+
+        $this->app->make(ExceptionHandler::class)->report(new \RuntimeException('boom'));
+    }
+
+    public function testErrbitFailureDoesNotBreakErrorHandling()
+    {
+        $this->enableErrbit();
+
+        $notifier = $this->createMock(Notifier::class);
+        $notifier->method('notify')->willThrowException(new \Exception('errbit is down'));
+        $this->app->instance(Notifier::class, $notifier);
+
+        $this->app->make(ExceptionHandler::class)->report(new \RuntimeException('boom'));
+
+        // Reaching this point means the notifier exception was swallowed.
+        $this->assertTrue(true);
+    }
+
+    public function testNotifierIsResolvedFromConfig()
+    {
+        $this->enableErrbit();
+
+        $notifier = $this->app->make(Notifier::class);
+
+        $this->assertInstanceOf(Notifier::class, $notifier);
+    }
+}


### PR DESCRIPTION
## Summary

Reports unhandled exceptions to the self-hosted Errbit instance at errors.catlab.eu via the `airbrake/phpbrake` package (Errbit speaks the Airbrake v3 notice API).

- **`ErrbitServiceProvider`** registers `Airbrake\Notifier` as a lazy singleton, configured from `config/services.php` / `ERRBIT_*` env vars. phpbrake's remote-config fetch is disabled (`remoteConfig => false`) — it phones home to airbrake.io and silently disables all notifications when using a custom Errbit host.
- **`Handler::report()`** sends exceptions to Errbit when reporting is enabled and the exception passes `shouldReport()` (existing `$dontReport` list is respected). Notifier failures are swallowed so Errbit downtime never breaks error handling.
- Reporting defaults to on only when `APP_ENV=production`; override with `ERRBIT_ENABLED`.
- The project key is not committed — `.env.example` documents the vars; the production server's `.env` needs `ERRBIT_HOST`, `ERRBIT_PROJECT_ID` and `ERRBIT_PROJECT_KEY`.

Also guards two spots that made the app unbootable without a database (`ReferenceController` route registration, `Organisation` `HTTP_HOST` lookup) so the suite runs locally.

## Testing

- `tests/Unit/Errbit/ErrbitReportingTest` (5 tests): exceptions reach the notifier, `$dontReport` exceptions don't, disabled config sends nothing, notifier failures don't propagate, notifier resolves from config. Unit suite green.
- Live smoke test against errors.catlab.eu accepted a notice (id returned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013HqprN6hPwwHLXeCRbGdgo