### PR TITLE
Pin phpbrake to 0.8.0 for PHP 8.0 compatibility

### DIFF
--- a/app/Errbit/Notifier.php
+++ b/app/Errbit/Notifier.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * CatLab Events - Event ticketing system
+ * Copyright (C) 2017 Thijs Van der Schaeghe
+ * CatLab Interactive bvba, Gent, Belgium
+ * http://www.catlab.eu/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace App\Errbit;
+
+use Airbrake\Notifier as AirbrakeNotifier;
+
+/**
+ * Class Notifier
+ *
+ * phpbrake 0.8.0 (the last release that supports PHP 8.0) checks its
+ * options with empty(), which silently flips remoteConfig=false back to
+ * true. The notifier then phones home to airbrake.io for configuration,
+ * which disables all notifications when talking to a self-hosted Errbit.
+ * This subclass re-applies the option after construction.
+ *
+ * @package App\Errbit
+ */
+class Notifier extends AirbrakeNotifier
+{
+    /**
+     * @param array $opt
+     * @throws \Airbrake\Exception
+     */
+    public function __construct($opt)
+    {
+        parent::__construct($opt);
+
+        if (array_key_exists('remoteConfig', $opt)) {
+            $this->opt['remoteConfig'] = $opt['remoteConfig'];
+        }
+    }
+}

--- a/app/Providers/ErrbitServiceProvider.php
+++ b/app/Providers/ErrbitServiceProvider.php
@@ -22,7 +22,8 @@
 
 namespace App\Providers;
 
-use Airbrake\Notifier;
+use Airbrake\Notifier as AirbrakeNotifier;
+use App\Errbit\Notifier;
 use Illuminate\Support\ServiceProvider;
 
 /**
@@ -41,7 +42,7 @@ class ErrbitServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->singleton(Notifier::class, function ($app) {
+        $this->app->singleton(AirbrakeNotifier::class, function ($app) {
             $config = $app['config']['services.errbit'];
 
             return new Notifier([

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "php": ">=8.0",
         "ext-json": "*",
         "ext-simplexml": "*",
-        "airbrake/phpbrake": "^1.0",
+        "airbrake/phpbrake": "0.8.0",
         "barryvdh/laravel-debugbar": "^3.2",
         "barryvdh/laravel-dompdf": "^1.0.0",
         "catlabinteractive/central-storage-client": "~1.0.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,33 +4,32 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c6f914964f07b4b6a74c638b91d943f4",
+    "content-hash": "f84ad7e158bde76dac9e8f7baad83a99",
     "packages": [
         {
             "name": "airbrake/phpbrake",
-            "version": "v1.0.0",
+            "version": "v0.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/airbrake/phpbrake.git",
-                "reference": "c5c354934fa879a70e0e6167f7269fe39935beca"
+                "reference": "05a972a5c1ee43367f489357153e757b9d0b1095"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/airbrake/phpbrake/zipball/c5c354934fa879a70e0e6167f7269fe39935beca",
-                "reference": "c5c354934fa879a70e0e6167f7269fe39935beca",
+                "url": "https://api.github.com/repos/airbrake/phpbrake/zipball/05a972a5c1ee43367f489357153e757b9d0b1095",
+                "reference": "05a972a5c1ee43367f489357153e757b9d0b1095",
                 "shasum": ""
             },
             "require": {
                 "cash/lrucache": "^1.0",
                 "guzzlehttp/guzzle": ">=6.3",
-                "php": ">=8.1"
+                "php": ">=5.4"
             },
             "require-dev": {
                 "mikey179/vfsstream": "^1.6",
                 "monolog/monolog": "^1.22|^2.0",
-                "phpunit/phpunit": "^10.0",
-                "psy/psysh": "^0.11",
-                "squizlabs/php_codesniffer": "^3.7"
+                "phpunit/phpunit": "^5.7",
+                "squizlabs/php_codesniffer": "^2.9"
             },
             "suggest": {
                 "guzzlehttp/guzzle": "Guzzle HTTP client"
@@ -42,9 +41,6 @@
                 }
             },
             "autoload": {
-                "files": [
-                    "src/constants.php"
-                ],
                 "psr-4": {
                     "Airbrake\\": "src/"
                 }
@@ -64,9 +60,9 @@
             ],
             "support": {
                 "issues": "https://github.com/airbrake/phpbrake/issues",
-                "source": "https://github.com/airbrake/phpbrake/tree/v1.0.0"
+                "source": "https://github.com/airbrake/phpbrake/tree/v0.8.0"
             },
-            "time": "2023-12-07T00:39:40+00:00"
+            "time": "2021-04-06T01:29:47+00:00"
         },
         {
             "name": "barryvdh/laravel-debugbar",

--- a/tests/Unit/Errbit/ErrbitReportingTest.php
+++ b/tests/Unit/Errbit/ErrbitReportingTest.php
@@ -77,4 +77,19 @@ class ErrbitReportingTest extends TestCase
 
         $this->assertInstanceOf(Notifier::class, $notifier);
     }
+
+    public function testRemoteConfigStaysDisabled()
+    {
+        // phpbrake 0.8.0's constructor uses empty() and silently flips
+        // remoteConfig=false back to true, making it phone home to
+        // airbrake.io and disable all notifications.
+        $this->enableErrbit();
+
+        $notifier = $this->app->make(Notifier::class);
+
+        $opt = new \ReflectionProperty(Notifier::class, 'opt');
+        $opt->setAccessible(true);
+
+        $this->assertFalse($opt->getValue($notifier)['remoteConfig']);
+    }
 }


### PR DESCRIPTION
## Summary

The dokku build failed because production runs PHP 8.0 and phpbrake v1.0.0 requires >= 8.1. This pins `airbrake/phpbrake` to `0.8.0` (the last release supporting PHP 8.0).

0.8.0 has a bug the previous version didn't: its constructor checks options with `empty()`, silently flipping `remoteConfig => false` back to `true` — so the notifier phones home to airbrake.io for configuration and disables all notifications when talking to a self-hosted Errbit. A small `App\Errbit\Notifier` subclass re-applies the option after construction; a regression test guards it.

The exact-version pin is intentional: bump to `^1.0` when production moves to PHP 8.1+ (the subclass workaround stays compatible — v1.0.0 fixed the `empty()` check).

## Testing

- Unit suite green (7 tests), including a new regression test asserting `remoteConfig` stays disabled on the resolved notifier.
- Live smoke test on phpbrake 0.8.0 against errors.catlab.eu: notice accepted (id returned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013HqprN6hPwwHLXeCRbGdgo