### PR TITLE
Upgrade production image to PHP 8.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG NODE_VERSION=18
 ARG PHP_EXTENSIONS="mysqli pdo_mysql bcmath zip intl gd"
 
-FROM thecodingmachine/php:8.0-v5-slim-apache
+FROM thecodingmachine/php:8.5-v5-slim-apache
 ENV APACHE_DOCUMENT_ROOT=public/
 
 # Configure locales

--- a/composer.lock
+++ b/composer.lock
@@ -3411,34 +3411,39 @@
         },
         {
             "name": "nette/schema",
-            "version": "v1.2.5",
+            "version": "v1.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/schema.git",
-                "reference": "0462f0166e823aad657c9224d0f849ecac1ba10a"
+                "reference": "f0ab1a3cda782dbc5da270d28545236aa80c4002"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/schema/zipball/0462f0166e823aad657c9224d0f849ecac1ba10a",
-                "reference": "0462f0166e823aad657c9224d0f849ecac1ba10a",
+                "url": "https://api.github.com/repos/nette/schema/zipball/f0ab1a3cda782dbc5da270d28545236aa80c4002",
+                "reference": "f0ab1a3cda782dbc5da270d28545236aa80c4002",
                 "shasum": ""
             },
             "require": {
-                "nette/utils": "^2.5.7 || ^3.1.5 ||  ^4.0",
-                "php": "7.1 - 8.3"
+                "nette/utils": "^4.0",
+                "php": "8.1 - 8.5"
             },
             "require-dev": {
-                "nette/tester": "^2.3 || ^2.4",
-                "phpstan/phpstan-nette": "^1.0",
-                "tracy/tracy": "^2.7"
+                "nette/phpstan-rules": "^1.0",
+                "nette/tester": "^2.6",
+                "phpstan/extension-installer": "^1.4@stable",
+                "phpstan/phpstan": "^2.1.39@stable",
+                "tracy/tracy": "^2.8"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2-dev"
+                    "dev-master": "1.3-dev"
                 }
             },
             "autoload": {
+                "psr-4": {
+                    "Nette\\": "src"
+                },
                 "classmap": [
                     "src/"
                 ]
@@ -3467,40 +3472,42 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/schema/issues",
-                "source": "https://github.com/nette/schema/tree/v1.2.5"
+                "source": "https://github.com/nette/schema/tree/v1.3.5"
             },
-            "time": "2023-10-05T20:37:59+00:00"
+            "time": "2026-02-23T03:47:12+00:00"
         },
         {
             "name": "nette/utils",
-            "version": "v4.0.5",
+            "version": "v4.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/utils.git",
-                "reference": "736c567e257dbe0fcf6ce81b4d6dbe05c6899f96"
+                "reference": "b043439dbdf954e6c28b5ea7e34b0100f83165e0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/utils/zipball/736c567e257dbe0fcf6ce81b4d6dbe05c6899f96",
-                "reference": "736c567e257dbe0fcf6ce81b4d6dbe05c6899f96",
+                "url": "https://api.github.com/repos/nette/utils/zipball/b043439dbdf954e6c28b5ea7e34b0100f83165e0",
+                "reference": "b043439dbdf954e6c28b5ea7e34b0100f83165e0",
                 "shasum": ""
             },
             "require": {
-                "php": "8.0 - 8.4"
+                "php": "8.2 - 8.5"
             },
             "conflict": {
                 "nette/finder": "<3",
                 "nette/schema": "<1.2.2"
             },
             "require-dev": {
-                "jetbrains/phpstorm-attributes": "dev-master",
+                "jetbrains/phpstorm-attributes": "^1.2",
+                "nette/phpstan-rules": "^1.0",
                 "nette/tester": "^2.5",
-                "phpstan/phpstan": "^1.0",
+                "phpstan/extension-installer": "^1.4@stable",
+                "phpstan/phpstan": "^2.1@stable",
                 "tracy/tracy": "^2.9"
             },
             "suggest": {
                 "ext-gd": "to use Image",
-                "ext-iconv": "to use Strings::webalize(), toAscii(), chr() and reverse()",
+                "ext-iconv": "to use Strings::chr(), ord() and reverse()",
                 "ext-intl": "to use Strings::webalize(), toAscii(), normalize() and compare()",
                 "ext-json": "to use Nette\\Utils\\Json",
                 "ext-mbstring": "to use Strings::lower() etc...",
@@ -3509,10 +3516,13 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-master": "4.1-dev"
                 }
             },
             "autoload": {
+                "psr-4": {
+                    "Nette\\": "src"
+                },
                 "classmap": [
                     "src/"
                 ]
@@ -3553,9 +3563,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/utils/issues",
-                "source": "https://github.com/nette/utils/tree/v4.0.5"
+                "source": "https://github.com/nette/utils/tree/v4.1.5"
             },
-            "time": "2024-08-07T15:39:19+00:00"
+            "time": "2026-07-17T23:02:45+00:00"
         },
         {
             "name": "nikic/php-parser",

--- a/tests/Unit/Errbit/ErrbitReportingTest.php
+++ b/tests/Unit/Errbit/ErrbitReportingTest.php
@@ -77,4 +77,19 @@ class ErrbitReportingTest extends TestCase
 
         $this->assertInstanceOf(Notifier::class, $notifier);
     }
+
+    public function testRemoteConfigStaysDisabled()
+    {
+        // phpbrake 0.8.0's constructor uses empty() and silently flips
+        // remoteConfig=false back to true, making it phone home to
+        // airbrake.io and disable all notifications.
+        $this->enableErrbit();
+
+        $notifier = $this->app->make(Notifier::class);
+
+        $opt = new \ReflectionProperty(Notifier::class, 'opt');
+        $opt->setAccessible(true);
+
+        $this->assertFalse($opt->getValue($notifier)['remoteConfig']);
+    }
 }


### PR DESCRIPTION
## Summary

Instead of pinning phpbrake down to PHP 8.0 (#48), this upgrades production to the latest stable PHP.

- Docker base image: `thecodingmachine/php:8.0-v5-slim-apache` → `8.5-v5-slim-apache`
- `composer.lock`: only `nette/schema` and `nette/utils` capped the PHP version; targeted update lifts the cap (`composer why-not php 8.5` is now clean). phpbrake stays on v1.0.0 (requires PHP ≥ 8.1, and its `remoteConfig` constructor bug is fixed there).
- Keeps the regression test from #48: the resolved notifier must keep `remoteConfig` disabled, otherwise phpbrake phones home to airbrake.io and silently disables all notifications for a self-hosted Errbit.

## Verification

- Full `docker build` of this branch succeeds (composer platform checks pass inside the container, npm prod build OK)
- `php artisan --version` boots inside the built image (Laravel 9.0.2, deprecation warnings only)
- Unit suite green (7 tests) on PHP 8.5.4
- Live smoke test against errors.catlab.eu on phpbrake v1.0.0: notice accepted

## Notes

- Laravel 9.0.2 predates official PHP 8.5 support, so expect implicit-nullable deprecation warnings in logs. A follow-up `laravel/framework 9.0.* → ^9.52` update (last of the 9.x line, ~3 years of fixes) would quiet most of those; kept out of this PR to keep the diff reviewable.
- If the deploy misbehaves, dokku retags the previous image on failed builds, and reverting this PR restores PHP 8.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013HqprN6hPwwHLXeCRbGdgo