### PR TITLE
Add integration tests for the base website and ticket purchase flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,3 +66,6 @@ GOOGLE_MAPS_API_KEY=
 ERRBIT_HOST=
 ERRBIT_PROJECT_ID=1
 ERRBIT_PROJECT_KEY=
+
+# Host port for the docker-compose MySQL service (default 3312)
+#MYSQL_HOST_PORT=3312

--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -33,7 +33,6 @@ use App\Models\User;
 use App\Models\Venue;
 use App\UitDB\Exceptions\UitPASException;
 use Auth;
-use CatLab\Accounts\Client\ApiClient;
 use Illuminate\Http\Request;
 
 /**
@@ -745,7 +744,7 @@ class EventController extends Controller
             ]);
         }
 
-        $client = new ApiClient($user);
+        $client = app(\App\Services\CatLabApiClientFactory::class)->forUser($user);
 
         // create a default order
         $waitingListAccessToken = self::getValidWaitingListToken($event);

--- a/app/Listeners/SendEmail.php
+++ b/app/Listeners/SendEmail.php
@@ -6,7 +6,6 @@ use App\Models\Event;
 use App\Models\Group;
 use App\Models\Order;
 use App\Models\User;
-use CatLab\Accounts\Client\ApiClient;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Exception\RequestException;
 
@@ -43,7 +42,7 @@ abstract class SendEmail
         }
 
         /** @var User $user */
-        $apiClient = new ApiClient($user);
+        $apiClient = app(\App\Services\CatLabApiClientFactory::class)->forUser($user);
 
         /* @TODO
          * This is not okay as some group members might not have logged in for a long time and might thus have
@@ -84,7 +83,7 @@ abstract class SendEmail
 
         /** @var User $user */
         $user = $order->user;
-        $apiClient = new ApiClient($user);
+        $apiClient = app(\App\Services\CatLabApiClientFactory::class)->forUser($user);
 
         try {
             $apiClient->sendEmail(

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -163,8 +163,12 @@ class Order extends \CatLab\Charon\Laravel\Database\Model implements EuklesModel
     public function synchronize($forceTrigger = false)
     {
         // No catlab id? Order was not registered succesfully, so cancel it now.
+        // Only applies to orders still pending payment: accepted orders (free
+        // tickets never get a catlab order id) must not be touched.
         if (!$this->catlab_order_id) {
-            $this->changeState(self::STATE_CANCELLED);
+            if ($this->isPending()) {
+                $this->changeState(self::STATE_CANCELLED);
+            }
             return;
         }
 

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -25,7 +25,6 @@ namespace App\Models;
 use App\Events\OrderCancelled;
 use App\Events\OrderConfirmed;
 use App\Tools\TicketPriceCalculator;
-use CatLab\Accounts\Client\ApiClient;
 use CatLab\Eukles\Client\Interfaces\EuklesModel;
 use GuzzleHttp\Client;
 use Illuminate\Database\Eloquent\Builder;
@@ -195,12 +194,8 @@ class Order extends \CatLab\Charon\Laravel\Database\Model implements EuklesModel
             return null;
         }
 
-        if ($expanded) {
-            $client = new ApiClient($this->user);
-        } else {
-            $client = new ApiClient(null);
-        }
-
+        $factory = app(\App\Services\CatLabApiClientFactory::class);
+        $client = $factory->forUser($expanded ? $this->user : null);
 
         return $client->getOrder($this->catlab_order_id, $expanded);
     }

--- a/app/Services/CatLabApiClientFactory.php
+++ b/app/Services/CatLabApiClientFactory.php
@@ -39,7 +39,7 @@ class CatLabApiClientFactory
      * @param User|null $user
      * @return ApiClient
      */
-    public function forUser(User $user = null): ApiClient
+    public function forUser(?User $user = null): ApiClient
     {
         return new ApiClient($user);
     }

--- a/app/Services/CatLabApiClientFactory.php
+++ b/app/Services/CatLabApiClientFactory.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * CatLab Events - Event ticketing system
+ * Copyright (C) 2017 Thijs Van der Schaeghe
+ * CatLab Interactive bvba, Gent, Belgium
+ * http://www.catlab.eu/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace App\Services;
+
+use App\Models\User;
+use CatLab\Accounts\Client\ApiClient;
+
+/**
+ * Class CatLabApiClientFactory
+ *
+ * Single construction point for the CatLab Accounts API client so that
+ * tests can swap the container binding for a fake.
+ *
+ * @package App\Services
+ */
+class CatLabApiClientFactory
+{
+    /**
+     * @param User|null $user
+     * @return ApiClient
+     */
+    public function forUser(User $user = null): ApiClient
+    {
+        return new ApiClient($user);
+    }
+}

--- a/bin/integration-tests.sh
+++ b/bin/integration-tests.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Runs the Integration testsuite inside the docker-compose webserver container
+# against a dedicated catlab_events_test database (dev data is never touched).
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+docker compose up -d mysql-db webserver
+
+# Wait for MySQL to accept connections, then ensure the test db exists.
+docker compose exec -T mysql-db bash -c \
+  'for i in $(seq 1 30); do mysqladmin ping -uroot -p"$MYSQL_ROOT_PASSWORD" --silent && break; sleep 1; done'
+docker compose exec -T mysql-db bash -c \
+  'mysql -uroot -p"$MYSQL_ROOT_PASSWORD" -e "CREATE DATABASE IF NOT EXISTS catlab_events_test"'
+
+docker compose exec -T webserver php vendor/bin/phpunit -c phpunit.integration.xml "$@"

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     },
     "require-dev": {
         "fzaninotto/faker": "~1.4",
-        "mockery/mockery": "0.9.*",
+        "mockery/mockery": "^1.6",
         "phpunit/phpunit": "~8.0"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c6f914964f07b4b6a74c638b91d943f4",
+    "content-hash": "9fc75438d450547ec83fc4c6663580c3",
     "packages": [
         {
             "name": "airbrake/phpbrake",
@@ -7467,20 +7467,20 @@
         },
         {
             "name": "hamcrest/hamcrest-php",
-            "version": "v1.2.2",
+            "version": "v2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hamcrest/hamcrest-php.git",
-                "reference": "b37020aa976fa52d3de9aa904aa2522dc518f79c"
+                "reference": "f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/b37020aa976fa52d3de9aa904aa2522dc518f79c",
-                "reference": "b37020aa976fa52d3de9aa904aa2522dc518f79c",
+                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487",
+                "reference": "f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.2"
+                "php": "^7.4|^8.0"
             },
             "replace": {
                 "cordoval/hamcrest-php": "*",
@@ -7488,21 +7488,23 @@
                 "kodova/hamcrest-php": "*"
             },
             "require-dev": {
-                "phpunit/php-file-iterator": "1.3.3",
-                "satooshi/php-coveralls": "dev-master"
+                "phpunit/php-file-iterator": "^1.4 || ^2.0 || ^3.0",
+                "phpunit/phpunit": "^4.8.36 || ^5.7 || ^6.5 || ^7.0 || ^8.0 || ^9.0"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1-dev"
+                }
+            },
             "autoload": {
-                "files": [
-                    "hamcrest/Hamcrest.php"
-                ],
                 "classmap": [
                     "hamcrest"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "BSD"
+                "BSD-3-Clause"
             ],
             "description": "This is the PHP port of Hamcrest Matchers",
             "keywords": [
@@ -7510,41 +7512,44 @@
             ],
             "support": {
                 "issues": "https://github.com/hamcrest/hamcrest-php/issues",
-                "source": "https://github.com/hamcrest/hamcrest-php/tree/master"
+                "source": "https://github.com/hamcrest/hamcrest-php/tree/v2.1.1"
             },
-            "time": "2015-05-11T14:41:42+00:00"
+            "time": "2025-04-30T06:54:44+00:00"
         },
         {
             "name": "mockery/mockery",
-            "version": "0.9.11",
+            "version": "1.6.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mockery/mockery.git",
-                "reference": "be9bf28d8e57d67883cba9fcadfcff8caab667f8"
+                "reference": "1f4efdd7d3beafe9807b08156dfcb176d18f1699"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mockery/mockery/zipball/be9bf28d8e57d67883cba9fcadfcff8caab667f8",
-                "reference": "be9bf28d8e57d67883cba9fcadfcff8caab667f8",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/1f4efdd7d3beafe9807b08156dfcb176d18f1699",
+                "reference": "1f4efdd7d3beafe9807b08156dfcb176d18f1699",
                 "shasum": ""
             },
             "require": {
-                "hamcrest/hamcrest-php": "~1.1",
+                "hamcrest/hamcrest-php": "^2.0.1",
                 "lib-pcre": ">=7.0",
-                "php": ">=5.3.2"
+                "php": ">=7.3"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
+                "phpunit/phpunit": "^8.5 || ^9.6.17",
+                "symplify/easy-coding-standard": "^12.1.14"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "0.9.x-dev"
-                }
-            },
             "autoload": {
-                "psr-0": {
-                    "Mockery": "library/"
+                "files": [
+                    "library/helpers.php",
+                    "library/Mockery.php"
+                ],
+                "psr-4": {
+                    "Mockery\\": "library/Mockery"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -7555,16 +7560,24 @@
                 {
                     "name": "Pádraic Brady",
                     "email": "padraic.brady@gmail.com",
-                    "homepage": "http://blog.astrumfutura.com"
+                    "homepage": "https://github.com/padraic",
+                    "role": "Author"
                 },
                 {
                     "name": "Dave Marshall",
                     "email": "dave.marshall@atstsolutions.co.uk",
-                    "homepage": "http://davedevelopment.co.uk"
+                    "homepage": "https://davedevelopment.co.uk",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Nathanael Esayeas",
+                    "email": "nathanael.esayeas@protonmail.com",
+                    "homepage": "https://github.com/ghostwriter",
+                    "role": "Lead Developer"
                 }
             ],
-            "description": "Mockery is a simple yet flexible PHP mock object framework for use in unit testing with PHPUnit, PHPSpec or any other testing framework. Its core goal is to offer a test double framework with a succinct API capable of clearly defining all possible object operations and interactions using a human readable Domain Specific Language (DSL). Designed as a drop in alternative to PHPUnit's phpunit-mock-objects library, Mockery is easy to integrate with PHPUnit and can operate alongside phpunit-mock-objects without the World ending.",
-            "homepage": "http://github.com/padraic/mockery",
+            "description": "Mockery is a simple yet flexible PHP mock object framework",
+            "homepage": "https://github.com/mockery/mockery",
             "keywords": [
                 "BDD",
                 "TDD",
@@ -7578,10 +7591,13 @@
                 "testing"
             ],
             "support": {
+                "docs": "https://docs.mockery.io/",
                 "issues": "https://github.com/mockery/mockery/issues",
-                "source": "https://github.com/mockery/mockery/tree/0.9"
+                "rss": "https://github.com/mockery/mockery/releases.atom",
+                "security": "https://github.com/mockery/mockery/security/advisories",
+                "source": "https://github.com/mockery/mockery"
             },
-            "time": "2019-02-12T16:07:13+00:00"
+            "time": "2024-05-16T03:13:13+00:00"
         },
         {
             "name": "myclabs/deep-copy",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,4 +24,5 @@ services:
     env_file:
       - ./.env
     ports:
-      - "3312:3306"
+      # Override with MYSQL_HOST_PORT in .env if 3312 is taken by another project.
+      - "${MYSQL_HOST_PORT:-3312}:3306"

--- a/docs/superpowers/plans/2026-07-24-integration-tests.md
+++ b/docs/superpowers/plans/2026-07-24-integration-tests.md
@@ -1,0 +1,857 @@
+# Integration Tests Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** HTTP-level integration tests proving the public site renders and the full ticket purchase flow (free + paid) works against real MySQL, with all external services faked.
+
+**Architecture:** A separate `Integration` phpunit suite runs inside the docker-compose `webserver` container against a dedicated `catlab_events_test` database on the `mysql-db` service. The only production change is a `CatLabApiClientFactory` seam replacing three direct `new ApiClient(...)` calls, so tests can swap in a fake. Eukles tracking is faked by rebinding its container interface.
+
+**Tech Stack:** Laravel 9, PHPUnit 8.5, MySQL 8 (docker-compose), PHP 8.5 container.
+
+## Global Constraints
+
+- Branch: `feature/integration-tests` (based on `upgrade/php-8.5` — the docker image needs PHP 8.5).
+- Spec: `docs/superpowers/specs/2026-07-24-integration-tests-design.md`.
+- Integration tests live in `tests/Integration/` and run ONLY via `phpunit.integration.xml`; the default `phpunit.xml` (Unit/Feature suites) must stay DB-free and green when run on the host: `vendor/bin/phpunit --testsuite Unit`.
+- Integration runs happen inside docker: `bin/integration-tests.sh` (never against the dev database `catlab-events`; always `catlab_events_test`).
+- No test may perform external HTTP. Fakes are hand-written classes (the bundled mockery 0.9 is too old — do not use it; PHPUnit `createMock` is fine for unit tests).
+- PHPUnit 8 syntax: no attributes, docblock annotations only.
+- Production code changes are limited to: `App\Services\CatLabApiClientFactory` (new), the three `new ApiClient` call sites, and — only if a test exposes a blocking bug — a minimal fix agreed with the user (STOP and report first).
+- Commit after each task with the trailer:
+  `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>` and
+  `Claude-Session: https://claude.ai/code/session_013HqprN6hPwwHLXeCRbGdgo`
+
+---
+
+### Task 1: Integration harness (config, runner script, base test case)
+
+**Files:**
+- Create: `phpunit.integration.xml`
+- Create: `bin/integration-tests.sh` (chmod +x)
+- Create: `tests/Integration/IntegrationTestCase.php`
+- Test: `tests/Integration/HarnessTest.php`
+
+**Interfaces:**
+- Produces: `Tests\Integration\IntegrationTestCase` — abstract, `use RefreshDatabase`; all integration tests extend it. Runner: `bin/integration-tests.sh [phpunit args]`.
+
+- [ ] **Step 1: Write the failing test**
+
+`tests/Integration/HarnessTest.php`:
+
+```php
+<?php
+
+namespace Tests\Integration;
+
+class HarnessTest extends IntegrationTestCase
+{
+    public function testRunsAgainstDedicatedTestDatabase()
+    {
+        $this->assertEquals('catlab_events_test', \DB::connection()->getDatabaseName());
+    }
+
+    public function testStatusEndpointResponds()
+    {
+        $this->get('/status')->assertStatus(200);
+    }
+}
+```
+
+- [ ] **Step 2: Write the harness files**
+
+`tests/Integration/IntegrationTestCase.php`:
+
+```php
+<?php
+
+namespace Tests\Integration;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+abstract class IntegrationTestCase extends TestCase
+{
+    use RefreshDatabase;
+}
+```
+
+`phpunit.integration.xml` (bootstrap and converters copied from `phpunit.xml`):
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         bootstrap="bootstrap/autoload.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false">
+    <testsuites>
+        <testsuite name="Integration">
+            <directory suffix="Test.php">./tests/Integration</directory>
+        </testsuite>
+    </testsuites>
+    <php>
+        <env name="APP_ENV" value="testing"/>
+        <env name="CACHE_DRIVER" value="array"/>
+        <env name="SESSION_DRIVER" value="array"/>
+        <env name="QUEUE_DRIVER" value="sync"/>
+        <!-- Dedicated test database on the docker-compose mysql service.
+             DB_USERNAME=root because the runner creates the schema; the root
+             password equals DB_PASSWORD from .env (see docker-compose.yml). -->
+        <env name="DB_HOST" value="mysql-db"/>
+        <env name="DB_PORT" value="3306"/>
+        <env name="DB_DATABASE" value="catlab_events_test"/>
+        <env name="DB_USERNAME" value="root"/>
+        <!-- Keep auth local (actingAs works; no OAuth redirect) -->
+        <env name="CATLAB_CLIENT_ID" value=""/>
+        <!-- No external services -->
+        <env name="ERRBIT_ENABLED" value="false"/>
+        <env name="VALID_DOMAINS" value=""/>
+        <env name="EUKLES_SERVER" value=""/>
+    </php>
+</phpunit>
+```
+
+`bin/integration-tests.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Runs the Integration testsuite inside the docker-compose webserver container
+# against a dedicated catlab_events_test database (dev data is never touched).
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+docker compose up -d mysql-db webserver
+
+# Wait for MySQL to accept connections, then ensure the test db exists.
+docker compose exec -T mysql-db bash -c \
+  'for i in $(seq 1 30); do mysqladmin ping -uroot -p"$MYSQL_ROOT_PASSWORD" --silent && break; sleep 1; done'
+docker compose exec -T mysql-db bash -c \
+  'mysql -uroot -p"$MYSQL_ROOT_PASSWORD" -e "CREATE DATABASE IF NOT EXISTS catlab_events_test"'
+
+docker compose exec -T webserver php vendor/bin/phpunit -c phpunit.integration.xml "$@"
+```
+
+Then: `chmod +x bin/integration-tests.sh`
+
+- [ ] **Step 3: Run and verify**
+
+Run: `bin/integration-tests.sh`
+Expected: `RefreshDatabase` runs `migrate:fresh` on `catlab_events_test`, then both tests PASS.
+
+If a migration fails on the clean MySQL 8 database, STOP: report the failing migration and error to the user before changing any migration file (fixing it is in scope only after agreement — the spec counts "migrations run from scratch" as part of what we're proving).
+
+- [ ] **Step 4: Verify the host unit suite is untouched**
+
+Run (on host): `vendor/bin/phpunit --testsuite Unit`
+Expected: OK (7 tests) — no DB required.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add phpunit.integration.xml bin/integration-tests.sh tests/Integration/
+git commit -m "Add integration test harness running in docker against a test database"
+```
+
+---
+
+### Task 2: Event fixtures + smoke tests
+
+**Files:**
+- Create: `tests/Integration/Concerns/CreatesEventFixtures.php`
+- Test: `tests/Integration/SmokeTest.php`
+
+**Interfaces:**
+- Consumes: `IntegrationTestCase` (Task 1).
+- Produces: trait `Tests\Integration\Concerns\CreatesEventFixtures` with:
+  - `createOrganisation(): \App\Models\Organisation`
+  - `createEvent(\App\Models\Organisation $organisation): \App\Models\Event` — published, public, open registration, no team requirement, no campaign, starts in 30 days
+  - `createTicketCategory(\App\Models\Event $event, float $price): \App\Models\TicketCategory`
+  - `createUser(): \App\Models\User`
+
+- [ ] **Step 1: Write the failing test**
+
+`tests/Integration/SmokeTest.php`:
+
+```php
+<?php
+
+namespace Tests\Integration;
+
+use Tests\Integration\Concerns\CreatesEventFixtures;
+
+class SmokeTest extends IntegrationTestCase
+{
+    use CreatesEventFixtures;
+
+    public function testHomepageRenders()
+    {
+        $this->get('/')->assertStatus(200);
+    }
+
+    public function testEventPageRenders()
+    {
+        $event = $this->createEvent($this->createOrganisation());
+        $this->createTicketCategory($event, 10.0);
+
+        $response = $this->get('/events/' . $event->id);
+
+        $response->assertStatus(200);
+        $response->assertSee($event->name);
+    }
+
+    public function testTicketSelectionPageRendersForGuests()
+    {
+        $event = $this->createEvent($this->createOrganisation());
+        $this->createTicketCategory($event, 10.0);
+
+        // Guests get the "log in to register" explanation page.
+        $this->get('/events/' . $event->id . '/register')->assertStatus(200);
+    }
+}
+```
+
+- [ ] **Step 2: Write the fixtures trait**
+
+`tests/Integration/Concerns/CreatesEventFixtures.php`:
+
+```php
+<?php
+
+namespace Tests\Integration\Concerns;
+
+use App\Models\Event;
+use App\Models\Organisation;
+use App\Models\TicketCategory;
+use App\Models\User;
+use Carbon\Carbon;
+
+trait CreatesEventFixtures
+{
+    protected function createOrganisation(): Organisation
+    {
+        $organisation = new Organisation();
+        $organisation->name = 'Test organisation';
+        $organisation->save();
+
+        return $organisation;
+    }
+
+    protected function createEvent(Organisation $organisation): Event
+    {
+        $event = new Event();
+        $event->organisation()->associate($organisation);
+        $event->name = 'Test quiz night';
+        $event->is_published = true;
+        $event->startDate = Carbon::now()->addDays(30);
+        $event->endDate = Carbon::now()->addDays(30)->addHours(4);
+        $event->visbility = 'public'; // (sic) column name has a typo in the schema
+        $event->registration = 'open';
+        $event->save();
+
+        return $event;
+    }
+
+    protected function createTicketCategory(Event $event, float $price): TicketCategory
+    {
+        $category = new TicketCategory();
+        $category->event()->associate($event);
+        $category->name = $price > 0 ? 'Paid ticket' : 'Free ticket';
+        $category->price = $price;
+        $category->save();
+
+        return $category;
+    }
+
+    protected function createUser(): User
+    {
+        $user = new User();
+        $user->name = 'Test User';
+        $user->email = uniqid('test', true) . '@example.com';
+        $user->password = bcrypt('secret');
+        $user->save();
+
+        return $user;
+    }
+}
+```
+
+- [ ] **Step 3: Run and verify**
+
+Run: `bin/integration-tests.sh --filter SmokeTest`
+Expected: PASS (3 tests).
+
+If a NOT NULL column or a blade view demands an attribute the fixture doesn't set, add that column to the fixture with an obviously-fake value — keep the trait the single place fixtures are defined. If a view itself crashes (not a fixture gap), STOP and report: that's a real rendering bug the smoke test just caught.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/Integration/
+git commit -m "Add event fixtures and public-page smoke tests"
+```
+
+---
+
+### Task 3: CatLabApiClientFactory seam (only production change)
+
+**Files:**
+- Create: `app/Services/CatLabApiClientFactory.php`
+- Modify: `app/Http/Controllers/EventController.php:748` (`$client = new ApiClient($user);`)
+- Modify: `app/Models/Order.php:192-206` (`getOrderData`)
+- Modify: `app/Listeners/SendEmail.php` (two sites: `sendConfirmationEmail`, `sendCancellationEmail` — both do `new ApiClient($user)`)
+- Test: `tests/Unit/Services/CatLabApiClientFactoryTest.php`
+
+**Interfaces:**
+- Produces: `App\Services\CatLabApiClientFactory::forUser(?\App\Models\User $user = null): \CatLab\Accounts\Client\ApiClient`, resolved from the container (`app(CatLabApiClientFactory::class)`), no explicit provider binding needed (auto-resolvable, zero constructor args). Tasks 4-5 swap it via `$this->app->instance(CatLabApiClientFactory::class, $fake)`.
+
+- [ ] **Step 1: Write the failing test**
+
+`tests/Unit/Services/CatLabApiClientFactoryTest.php` (runs on the host, no DB):
+
+```php
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Services\CatLabApiClientFactory;
+use CatLab\Accounts\Client\ApiClient;
+use Tests\TestCase;
+
+class CatLabApiClientFactoryTest extends TestCase
+{
+    public function testCreatesApiClient()
+    {
+        $factory = $this->app->make(CatLabApiClientFactory::class);
+
+        $this->assertInstanceOf(ApiClient::class, $factory->forUser(null));
+    }
+
+    public function testContainerBindingCanBeSwapped()
+    {
+        $fake = new class extends CatLabApiClientFactory {
+        };
+        $this->app->instance(CatLabApiClientFactory::class, $fake);
+
+        $this->assertSame($fake, $this->app->make(CatLabApiClientFactory::class));
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vendor/bin/phpunit --filter CatLabApiClientFactoryTest`
+Expected: ERROR — `Class "App\Services\CatLabApiClientFactory" not found`.
+
+- [ ] **Step 3: Write the factory**
+
+`app/Services/CatLabApiClientFactory.php` (include the standard GPL header used by all app files):
+
+```php
+<?php
+/* [GPL header identical to app/Providers/ErrbitServiceProvider.php] */
+
+namespace App\Services;
+
+use App\Models\User;
+use CatLab\Accounts\Client\ApiClient;
+
+/**
+ * Class CatLabApiClientFactory
+ *
+ * Single construction point for the CatLab Accounts API client so that
+ * tests can swap the container binding for a fake.
+ *
+ * @package App\Services
+ */
+class CatLabApiClientFactory
+{
+    /**
+     * @param User|null $user
+     * @return ApiClient
+     */
+    public function forUser(User $user = null): ApiClient
+    {
+        return new ApiClient($user);
+    }
+}
+```
+
+(Note: the GPL header comment is required — copy it verbatim from an existing app file; do not literally write the placeholder line above.)
+
+- [ ] **Step 4: Replace the three call sites**
+
+`app/Http/Controllers/EventController.php` — line 748:
+
+```php
+// before
+$client = new ApiClient($user);
+// after
+$client = app(\App\Services\CatLabApiClientFactory::class)->forUser($user);
+```
+
+`app/Models/Order.php` — `getOrderData()`:
+
+```php
+// before
+if ($expanded) {
+    $client = new ApiClient($this->user);
+} else {
+    $client = new ApiClient(null);
+}
+// after
+$factory = app(\App\Services\CatLabApiClientFactory::class);
+$client = $factory->forUser($expanded ? $this->user : null);
+```
+
+`app/Listeners/SendEmail.php` — in `sendConfirmationEmail` and `sendCancellationEmail`:
+
+```php
+// before (both methods)
+$apiClient = new ApiClient($user);
+// after
+$apiClient = app(\App\Services\CatLabApiClientFactory::class)->forUser($user);
+```
+
+Leave the now-unused `use CatLab\Accounts\Client\ApiClient;` imports only if still referenced (Order.php keeps none after the change — remove dead imports flagged by inspection, don't touch anything else).
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `vendor/bin/phpunit --testsuite Unit` (host) — expected OK (9 tests).
+Run: `bin/integration-tests.sh` — expected all integration tests still PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/Services/CatLabApiClientFactory.php app/Http/Controllers/EventController.php app/Models/Order.php app/Listeners/SendEmail.php tests/Unit/Services/
+git commit -m "Route CatLab Accounts ApiClient construction through a factory seam"
+```
+
+---
+
+### Task 4: Test doubles + free ticket purchase flow
+
+**Files:**
+- Create: `tests/Integration/Fakes/FakeCatLabApiClient.php`
+- Create: `tests/Integration/Fakes/FakeCatLabApiClientFactory.php`
+- Create: `tests/Integration/Fakes/FakeEuklesClient.php`
+- Modify: `tests/Integration/IntegrationTestCase.php` (bind fakes in `setUp`)
+- Test: `tests/Integration/FreeTicketPurchaseTest.php`
+
+**Interfaces:**
+- Consumes: `CatLabApiClientFactory` (Task 3), `CreatesEventFixtures` (Task 2).
+- Produces: `IntegrationTestCase->catlabApi` (public `FakeCatLabApiClient`) with:
+  - `$createOrderCalls` (array of payloads), `$sendEmailCalls` (array of `['subject','target']`), `$orderStatus` (string, default `'PENDING'`, returned by `getOrder`), `$nextOrderId` (int, default `4242`)
+  - `createOrder($data)` returns `['id' => $nextOrderId, 'payUrl' => 'https://pay.example.com/order/{id}']`
+
+- [ ] **Step 1: Write the failing test**
+
+`tests/Integration/FreeTicketPurchaseTest.php`:
+
+```php
+<?php
+
+namespace Tests\Integration;
+
+use App\Models\Order;
+use Tests\Integration\Concerns\CreatesEventFixtures;
+
+class FreeTicketPurchaseTest extends IntegrationTestCase
+{
+    use CreatesEventFixtures;
+
+    public function testFreeTicketPurchaseCompletesWithoutPayment()
+    {
+        $event = $this->createEvent($this->createOrganisation());
+        $category = $this->createTicketCategory($event, 0.0);
+        $user = $this->createUser();
+
+        $response = $this->actingAs($user)
+            ->post("/events/{$event->id}/register/{$category->id}/process");
+
+        $order = Order::query()->first();
+        $this->assertNotNull($order, 'An order should have been created');
+        $this->assertEquals(Order::STATE_ACCEPTED, $order->state);
+        $this->assertEquals($user->id, $order->user_id);
+        $response->assertRedirect(action('OrderController@thanks', [$order->id]));
+
+        // No payment API involved; confirmation email requested via the API.
+        $this->assertCount(0, $this->catlabApi->createOrderCalls);
+        $this->assertCount(1, $this->catlabApi->sendEmailCalls);
+
+        // The thanks page renders and the order STAYS accepted afterwards.
+        $this->actingAs($user)->get("/orders/{$order->id}/thanks")->assertStatus(200);
+        $this->assertEquals(Order::STATE_ACCEPTED, $order->fresh()->state);
+    }
+}
+```
+
+- [ ] **Step 2: Write the fakes**
+
+`tests/Integration/Fakes/FakeCatLabApiClient.php`:
+
+```php
+<?php
+
+namespace Tests\Integration\Fakes;
+
+use CatLab\Accounts\Client\ApiClient;
+
+class FakeCatLabApiClient extends ApiClient
+{
+    public $createOrderCalls = [];
+    public $sendEmailCalls = [];
+    public $orderStatus = 'PENDING';
+    public $nextOrderId = 4242;
+
+    public function __construct()
+    {
+        parent::__construct(null);
+    }
+
+    public function createOrder($data)
+    {
+        $this->createOrderCalls[] = $data;
+
+        return [
+            'id' => $this->nextOrderId,
+            'payUrl' => 'https://pay.example.com/order/' . $this->nextOrderId,
+        ];
+    }
+
+    public function getOrder($id, $expanded = false)
+    {
+        return [
+            'id' => $id,
+            'status' => $this->orderStatus,
+            'price' => 10.0,
+            'reference' => 'TEST-' . $id,
+        ];
+    }
+
+    public function sendEmail($subject, $body, $target = null)
+    {
+        $this->sendEmailCalls[] = ['subject' => $subject, 'target' => $target];
+
+        return true;
+    }
+}
+```
+
+`tests/Integration/Fakes/FakeCatLabApiClientFactory.php`:
+
+```php
+<?php
+
+namespace Tests\Integration\Fakes;
+
+use App\Models\User;
+use App\Services\CatLabApiClientFactory;
+use CatLab\Accounts\Client\ApiClient;
+
+class FakeCatLabApiClientFactory extends CatLabApiClientFactory
+{
+    private $client;
+
+    public function __construct(FakeCatLabApiClient $client)
+    {
+        $this->client = $client;
+    }
+
+    public function forUser(User $user = null): ApiClient
+    {
+        return $this->client;
+    }
+}
+```
+
+`tests/Integration/Fakes/FakeEuklesClient.php` (check `EuklesClient::__construct` signature — `(server, key, secret, environment)` — before writing):
+
+```php
+<?php
+
+namespace Tests\Integration\Fakes;
+
+use CatLab\Eukles\Client\EuklesClient;
+
+class FakeEuklesClient extends EuklesClient
+{
+    public $tracked = [];
+
+    public function __construct()
+    {
+        parent::__construct('https://eukles.invalid', 'test-key', 'test-secret', 'testing');
+    }
+
+    public function trackEvent(\CatLab\Eukles\Client\Models\Event $event)
+    {
+        $this->tracked[] = $event;
+
+        return true;
+    }
+
+    public function trackEvents(array $events)
+    {
+        foreach ($events as $event) {
+            $this->trackEvent($event);
+        }
+
+        return true;
+    }
+}
+```
+
+(If the `Models\Event` type hint doesn't match the parent signature, mirror the parent's exact parameter type — check `vendor/catlabinteractive/eukles-client/src/EuklesClient.php:177`.)
+
+- [ ] **Step 3: Bind fakes in IntegrationTestCase**
+
+Update `tests/Integration/IntegrationTestCase.php`:
+
+```php
+<?php
+
+namespace Tests\Integration;
+
+use App\Services\CatLabApiClientFactory;
+use CatLab\Eukles\Client\Interfaces\EuklesClient as EuklesClientInterface;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Integration\Fakes\FakeCatLabApiClient;
+use Tests\Integration\Fakes\FakeCatLabApiClientFactory;
+use Tests\Integration\Fakes\FakeEuklesClient;
+use Tests\TestCase;
+
+abstract class IntegrationTestCase extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @var FakeCatLabApiClient
+     */
+    protected $catlabApi;
+
+    /**
+     * @var FakeEuklesClient
+     */
+    protected $eukles;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->catlabApi = new FakeCatLabApiClient();
+        $this->app->instance(
+            CatLabApiClientFactory::class,
+            new FakeCatLabApiClientFactory($this->catlabApi)
+        );
+
+        $this->eukles = new FakeEuklesClient();
+        $this->app->instance(EuklesClientInterface::class, $this->eukles);
+    }
+}
+```
+
+(The Eukles facade resolves `CatLab\Eukles\Client\Interfaces\EuklesClient::class` from the container — see `EuklesClientFacade::getFacadeAccessor` — so `instance()` intercepts `\Eukles::trackEvent`.)
+
+- [ ] **Step 4: Run and verify**
+
+Run: `bin/integration-tests.sh --filter FreeTicketPurchaseTest`
+Expected: PASS.
+
+**Known risk, decided in advance:** `Order::synchronize()` cancels any order without a `catlab_order_id` (Order.php:167-170) — and free orders never get one. If the final assertions fail because visiting the thanks page flipped the order to `CANCELLED`, that is a REAL production bug the test just exposed. STOP, do not "fix the test", and report to the user with the failing output. (Likely minimal fix, only after user agreement: skip the cancel branch in `synchronize()` for orders whose ticket category is free, or skip `synchronize()` entirely for free orders.)
+
+- [ ] **Step 5: Run the full integration + unit suites**
+
+Run: `bin/integration-tests.sh` and `vendor/bin/phpunit --testsuite Unit`
+Expected: all PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/Integration/
+git commit -m "Add faked external services and free ticket purchase flow test"
+```
+
+---
+
+### Task 5: Paid ticket purchase flow
+
+**Files:**
+- Test: `tests/Integration/PaidTicketPurchaseTest.php`
+
+**Interfaces:**
+- Consumes: everything from Task 4 (`$this->catlabApi`, fixtures).
+
+- [ ] **Step 1: Write the failing test**
+
+`tests/Integration/PaidTicketPurchaseTest.php`:
+
+```php
+<?php
+
+namespace Tests\Integration;
+
+use App\Models\Order;
+use Tests\Integration\Concerns\CreatesEventFixtures;
+
+class PaidTicketPurchaseTest extends IntegrationTestCase
+{
+    use CreatesEventFixtures;
+
+    public function testPaidTicketPurchaseRedirectsToPaymentAndConfirmsViaCallback()
+    {
+        $event = $this->createEvent($this->createOrganisation());
+        $category = $this->createTicketCategory($event, 15.0);
+        $user = $this->createUser();
+
+        // Step 1: submit the order — should create a remote order and
+        // redirect the buyer to the payment page.
+        $response = $this->actingAs($user)
+            ->post("/events/{$event->id}/register/{$category->id}/process");
+
+        $order = Order::query()->first();
+        $this->assertNotNull($order, 'An order should have been created');
+        $this->assertEquals(Order::STATE_PENDING, $order->state);
+        $this->assertEquals($this->catlabApi->nextOrderId, $order->catlab_order_id);
+        $this->assertCount(1, $this->catlabApi->createOrderCalls);
+
+        $payload = $this->catlabApi->createOrderCalls[0];
+        $this->assertEquals($event->name, $payload['items'][0]['name']);
+
+        $response->assertStatus(302);
+        $this->assertStringStartsWith(
+            'https://pay.example.com/order/' . $this->catlabApi->nextOrderId,
+            $response->headers->get('Location')
+        );
+
+        // Step 2: the PSP reports payment — callback flips the order to
+        // accepted and triggers the confirmation email.
+        $this->catlabApi->orderStatus = 'ACCEPTED';
+        $this->get("/orders/{$order->id}/sync")->assertStatus(200);
+
+        $this->assertEquals(Order::STATE_ACCEPTED, $order->fresh()->state);
+        $this->assertCount(1, $this->catlabApi->sendEmailCalls);
+
+        // Step 3: the thanks page renders the confirmation.
+        $this->actingAs($user)->get("/orders/{$order->id}/thanks")->assertStatus(200);
+        $this->assertEquals(Order::STATE_ACCEPTED, $order->fresh()->state);
+    }
+}
+```
+
+- [ ] **Step 2: Run and verify**
+
+Run: `bin/integration-tests.sh --filter PaidTicketPurchaseTest`
+Expected: PASS. This exercises: `EventController::processRegister` (paid branch), `Order::getPayUrl`, the unauthenticated `OrderController::sync` callback, `Order::synchronize`/`changeState`, the `OrderConfirmed` listeners (email through the fake factory, Eukles through the fake client), and the thanks view.
+
+If `synchronize()` misbehaves (see the `$this->status` vs `state` mismatch at Order.php:175 — `status` is not a column, so the comparison is always against null), the test may still pass because the branch always executes. Only STOP and report if an assertion actually fails.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/Integration/PaidTicketPurchaseTest.php
+git commit -m "Add paid ticket purchase flow test with faked payment API"
+```
+
+---
+
+### Task 6: Auth guards
+
+**Files:**
+- Test: `tests/Integration/PurchaseGuardsTest.php`
+
+**Interfaces:**
+- Consumes: fixtures (Task 2).
+
+- [ ] **Step 1: Write the failing test**
+
+`tests/Integration/PurchaseGuardsTest.php`:
+
+```php
+<?php
+
+namespace Tests\Integration;
+
+use App\Models\Order;
+use Tests\Integration\Concerns\CreatesEventFixtures;
+
+class PurchaseGuardsTest extends IntegrationTestCase
+{
+    use CreatesEventFixtures;
+
+    public function testTicketRegistrationRequiresLogin()
+    {
+        $event = $this->createEvent($this->createOrganisation());
+        $category = $this->createTicketCategory($event, 10.0);
+
+        $this->get("/events/{$event->id}/register/{$category->id}")
+            ->assertRedirect('/login');
+    }
+
+    public function testProcessingAnOrderRequiresLogin()
+    {
+        $event = $this->createEvent($this->createOrganisation());
+        $category = $this->createTicketCategory($event, 10.0);
+
+        $this->post("/events/{$event->id}/register/{$category->id}/process")
+            ->assertRedirect('/login');
+
+        $this->assertEquals(0, Order::query()->count());
+    }
+}
+```
+
+- [ ] **Step 2: Run and verify**
+
+Run: `bin/integration-tests.sh --filter PurchaseGuardsTest`
+Expected: PASS (`CATLAB_CLIENT_ID` is empty in the integration config, so `Auth::routes()` provides `/login` and the `auth` middleware redirects there).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/Integration/PurchaseGuardsTest.php
+git commit -m "Add auth guard tests for the purchase routes"
+```
+
+---
+
+### Task 7: Documentation + full verification + PR
+
+**Files:**
+- Modify: `readme.md` (add a "Running tests" section)
+
+- [ ] **Step 1: Document the runners**
+
+Append to `readme.md`:
+
+```markdown
+## Running tests
+
+Unit tests (no database needed):
+
+    vendor/bin/phpunit --testsuite Unit
+
+Integration tests (runs inside docker against a dedicated
+`catlab_events_test` database; requires docker compose):
+
+    bin/integration-tests.sh
+
+Pass phpunit arguments through, e.g. `bin/integration-tests.sh --filter PaidTicketPurchaseTest`.
+```
+
+- [ ] **Step 2: Full verification**
+
+Run: `vendor/bin/phpunit --testsuite Unit` (host) — expected OK.
+Run: `bin/integration-tests.sh` — expected OK, all integration tests green.
+
+- [ ] **Step 3: Commit and open PR**
+
+```bash
+git add readme.md
+git commit -m "Document unit and integration test runners"
+git push -u origin feature/integration-tests
+gh pr create --base master --title "Add integration tests for the ticket purchase flow" ...
+```
+
+PR body: summarize suites, the factory seam, the docker runner, and CRUCIALLY any production bugs the tests exposed (free-order cancellation, synchronize status mismatch) with how they were handled. Note the PR depends on #49 (PHP 8.5) being merged first.

--- a/docs/superpowers/specs/2026-07-24-integration-tests-design.md
+++ b/docs/superpowers/specs/2026-07-24-integration-tests-design.md
@@ -1,0 +1,78 @@
+# Integration tests for the base website and ticket purchase flow
+
+**Date:** 2026-07-24
+**Status:** Approved
+**Depends on:** PR #49 (PHP 8.5 upgrade) — the docker image only builds from that branch
+
+## Goal
+
+HTTP-level integration tests that prove the public website renders and the
+full ticket purchase flow works — free and paid — against a real MySQL
+database, with all external services faked.
+
+## Where the tests run
+
+- New `Integration` testsuite in `tests/Integration/`, configured by
+  `phpunit.integration.xml` (separate from `phpunit.xml`; the existing
+  DB-free unit suite is unchanged).
+- Tests run inside the docker-compose `webserver` container (production
+  PHP + pdo_mysql) against the `mysql-db` service, using a dedicated
+  `catlab_events_test` database so dev data is never touched. The wrapper
+  script creates the database if missing.
+- `RefreshDatabase` migrates the schema fresh each run — this also proves
+  the migrations run end-to-end on a clean MySQL 8. (SQLite is not an
+  option: two order migrations use raw `ALTER TABLE ... CHANGE COLUMN`.)
+- Entry point: `bin/integration-tests.sh` →
+  `docker compose exec webserver vendor/bin/phpunit -c phpunit.integration.xml`.
+  Documented in the readme.
+- `phpunit.integration.xml` env: test DB credentials; `CATLAB_CLIENT_ID`
+  unset so auth routes stay local (`actingAs()` works); Errbit disabled;
+  Eukles/QuizWitz/UitPAS unconfigured.
+
+## Production seam (only production change)
+
+`CatLab\Accounts\Client\ApiClient` is currently constructed with `new` at
+three sites: `EventController::processRegister`, `Order::getOrderData`,
+`App\Listeners\SendEmail`. A new `App\Services\CatLabApiClientFactory`
+with `forUser(?User $user): ApiClient` is bound as a container singleton;
+the three sites resolve it instead of `new`-ing the client. Production
+behavior is unchanged. Tests swap the binding for a fake factory whose
+client records `createOrder` / `getOrder` / `sendEmail` calls and returns
+canned responses.
+
+## Fixtures
+
+`tests/Integration/Concerns/CreatesEventFixtures.php` — plain Eloquent
+builders (the legacy `ModelFactory.php` is dead code on Laravel 9):
+Organisation → Event (+ EventDate) → TicketCategory (free or paid) →
+User. `campaign_id` stays null so no QuizWitz call fires.
+
+## Test cases
+
+**Smoke** (`SmokeTest`): homepage, event detail page, and ticket-selection
+page each return 200 and render.
+
+**Free purchase** (`FreeTicketPurchaseTest`): logged-in user walks
+select → confirm → process; order ends in `STATE_ACCEPTED`; redirect to
+thanks page which renders; the fake client saw a `sendEmail`
+(confirmation) call and no `createOrder` call.
+
+**Paid purchase** (`PaidTicketPurchaseTest`): fake API returns
+`{id, payUrl}`; after process the order is pending with `catlab_order_id`
+set and the response redirects to the payUrl. Simulating the PSP return
+(`GET orders/{id}/sync`, unauthenticated by design) with the fake
+reporting an accepted status flips the order to `STATE_ACCEPTED`; the
+thanks page then renders the confirmation.
+
+**Guards** (`PurchaseGuardsTest`): unauthenticated requests to the
+register routes redirect to login.
+
+Eukles tracking is neutralized (unconfigured client or a bound spy —
+whichever its service provider supports, determined during
+implementation; sync queue means listeners run inline).
+
+## Out of scope
+
+Browser/JS end-to-end tests, the donation (pay.nl) flow, UitPAS
+subsidised tariffs, CI wiring (possible follow-up: GitHub Actions job
+running the same docker recipe).

--- a/phpunit.integration.xml
+++ b/phpunit.integration.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         bootstrap="bootstrap/autoload.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false">
+    <testsuites>
+        <testsuite name="Integration">
+            <directory suffix="Test.php">./tests/Integration</directory>
+        </testsuite>
+    </testsuites>
+    <php>
+        <env name="APP_ENV" value="testing"/>
+        <env name="CACHE_DRIVER" value="array"/>
+        <env name="SESSION_DRIVER" value="array"/>
+        <env name="QUEUE_DRIVER" value="sync"/>
+        <!-- Dedicated test database on the docker-compose mysql service.
+             DB_USERNAME=root because the runner creates the schema; the root
+             password equals DB_PASSWORD from .env (see docker-compose.yml). -->
+        <env name="DB_HOST" value="mysql-db"/>
+        <env name="DB_PORT" value="3306"/>
+        <env name="DB_DATABASE" value="catlab_events_test"/>
+        <env name="DB_USERNAME" value="root"/>
+        <!-- Keep auth local (actingAs works; no OAuth redirect) -->
+        <env name="CATLAB_CLIENT_ID" value=""/>
+        <!-- No external services -->
+        <env name="ERRBIT_ENABLED" value="false"/>
+        <env name="VALID_DOMAINS" value=""/>
+        <env name="EUKLES_SERVER" value=""/>
+    </php>
+</phpunit>

--- a/phpunit.integration.xml
+++ b/phpunit.integration.xml
@@ -31,5 +31,19 @@
         <env name="ERRBIT_ENABLED" value="false"/>
         <env name="VALID_DOMAINS" value=""/>
         <env name="EUKLES_SERVER" value=""/>
+        <!-- Deterministic Eukles config: the container inherits the developer's
+             .env, so without pinning these, EuklesEventSubscriber::subscribe()
+             (which gates registration on config('eukles.key')) would silently
+             vary by machine. A fixed key/secret makes it always register and
+             always hit the FakeEuklesClient bound in IntegrationTestCase. -->
+        <env name="EUKLES_PROJECT_KEY" value="test-key"/>
+        <env name="EUKLES_PROJECT_SECRET" value="test-secret"/>
+        <!-- Blank the UiTDatabank credentials actually read by
+             config/services.php (uitdb.*) so a developer's real .env values
+             can't leak into the test container and make behaviour depend on
+             the machine running the suite. -->
+        <env name="UITDB_OAUTH_CONSUMER" value=""/>
+        <env name="UITDB_OAUTH_SECRET" value=""/>
+        <env name="UITDB_ENTRY_API_KEY" value=""/>
     </php>
 </phpunit>

--- a/readme.md
+++ b/readme.md
@@ -64,3 +64,16 @@ live.quizwitz.com
 live.sittingbull.be
 quiz.gent
 www.quiz.gent
+
+## Running tests
+
+Unit tests (no database needed):
+
+    vendor/bin/phpunit --testsuite Unit
+
+Integration tests (runs inside docker against a dedicated
+`catlab_events_test` database; requires docker compose):
+
+    bin/integration-tests.sh
+
+Pass phpunit arguments through, e.g. `bin/integration-tests.sh --filter PaidTicketPurchaseTest`.

--- a/tests/Integration/Concerns/CreatesEventFixtures.php
+++ b/tests/Integration/Concerns/CreatesEventFixtures.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Integration\Concerns;
+
+use App\Models\Event;
+use App\Models\Organisation;
+use App\Models\TicketCategory;
+use App\Models\User;
+use Carbon\Carbon;
+
+trait CreatesEventFixtures
+{
+    protected function createOrganisation(): Organisation
+    {
+        $organisation = new Organisation();
+        $organisation->name = 'Test organisation';
+        $organisation->save();
+
+        return $organisation;
+    }
+
+    protected function createEvent(Organisation $organisation): Event
+    {
+        $event = new Event();
+        $event->organisation()->associate($organisation);
+        $event->name = 'Test quiz night';
+        // NOT NULL, no default in the schema; not part of the brief's fixture but required to save.
+        $event->description = 'Test event description.';
+        // NOT NULL, no default; must be one of Event::TYPE_EVENT / Event::TYPE_PACKAGE.
+        $event->event_type = Event::TYPE_EVENT;
+        $event->is_published = true;
+        // No team requirement, per the fixture's documented contract (column defaults to true).
+        $event->requires_team = false;
+        $event->visbility = 'public'; // (sic) column name has a typo in the schema
+        $event->registration = 'open';
+        $event->save();
+
+        // startDate/endDate no longer live on `events` (moved to `event_dates` by
+        // migration 2021_08_20_132431_create_event_dates.php); Event::startDate/endDate
+        // are now accessors computed from this relation.
+        $event->eventDates()->create([
+            'startDate' => Carbon::now()->addDays(30),
+            'endDate' => Carbon::now()->addDays(30)->addHours(4),
+        ]);
+
+        return $event;
+    }
+
+    protected function createTicketCategory(Event $event, float $price): TicketCategory
+    {
+        $category = new TicketCategory();
+        $category->event()->associate($event);
+        $category->name = $price > 0 ? 'Paid ticket' : 'Free ticket';
+        $category->price = $price;
+        $category->save();
+
+        return $category;
+    }
+
+    protected function createUser(): User
+    {
+        $user = new User();
+        $user->name = 'Test User';
+        $user->email = uniqid('test', true) . '@example.com';
+        $user->password = bcrypt('secret');
+        $user->save();
+
+        return $user;
+    }
+}

--- a/tests/Integration/Fakes/FakeCatLabApiClient.php
+++ b/tests/Integration/Fakes/FakeCatLabApiClient.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Integration\Fakes;
+
+use CatLab\Accounts\Client\ApiClient;
+
+class FakeCatLabApiClient extends ApiClient
+{
+    public $createOrderCalls = [];
+    public $sendEmailCalls = [];
+    public $orderStatus = 'PENDING';
+    public $nextOrderId = 4242;
+
+    public function __construct()
+    {
+        parent::__construct(null);
+    }
+
+    public function createOrder($data)
+    {
+        $this->createOrderCalls[] = $data;
+
+        return [
+            'id' => $this->nextOrderId,
+            'payUrl' => 'https://pay.example.com/order/' . $this->nextOrderId,
+        ];
+    }
+
+    public function getOrder($id, $expanded = false)
+    {
+        return [
+            'id' => $id,
+            'status' => $this->orderStatus,
+            'price' => 10.0,
+            'reference' => 'TEST-' . $id,
+        ];
+    }
+
+    public function sendEmail($subject, $body, $target = null)
+    {
+        $this->sendEmailCalls[] = ['subject' => $subject, 'target' => $target];
+
+        return true;
+    }
+}

--- a/tests/Integration/Fakes/FakeCatLabApiClientFactory.php
+++ b/tests/Integration/Fakes/FakeCatLabApiClientFactory.php
@@ -15,7 +15,7 @@ class FakeCatLabApiClientFactory extends CatLabApiClientFactory
         $this->client = $client;
     }
 
-    public function forUser(User $user = null): ApiClient
+    public function forUser(?User $user = null): ApiClient
     {
         return $this->client;
     }

--- a/tests/Integration/Fakes/FakeCatLabApiClientFactory.php
+++ b/tests/Integration/Fakes/FakeCatLabApiClientFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\Integration\Fakes;
+
+use App\Models\User;
+use App\Services\CatLabApiClientFactory;
+use CatLab\Accounts\Client\ApiClient;
+
+class FakeCatLabApiClientFactory extends CatLabApiClientFactory
+{
+    private $client;
+
+    public function __construct(FakeCatLabApiClient $client)
+    {
+        $this->client = $client;
+    }
+
+    public function forUser(User $user = null): ApiClient
+    {
+        return $this->client;
+    }
+}

--- a/tests/Integration/Fakes/FakeEuklesClient.php
+++ b/tests/Integration/Fakes/FakeEuklesClient.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Integration\Fakes;
+
+use CatLab\Eukles\Client\EuklesClient;
+
+class FakeEuklesClient extends EuklesClient
+{
+    public $tracked = [];
+
+    public function __construct()
+    {
+        parent::__construct('https://eukles.invalid', 'test-key', 'test-secret', 'testing');
+    }
+
+    public function trackEvent(\CatLab\Eukles\Client\Models\Event $event)
+    {
+        $this->tracked[] = $event;
+
+        return true;
+    }
+
+    public function trackEvents(array $events)
+    {
+        foreach ($events as $event) {
+            $this->trackEvent($event);
+        }
+
+        return true;
+    }
+}

--- a/tests/Integration/FreeTicketPurchaseTest.php
+++ b/tests/Integration/FreeTicketPurchaseTest.php
@@ -28,6 +28,9 @@ class FreeTicketPurchaseTest extends IntegrationTestCase
         $this->assertCount(0, $this->catlabApi->createOrderCalls);
         $this->assertCount(1, $this->catlabApi->sendEmailCalls);
 
+        // Order confirmation is tracked via the faked Eukles client.
+        $this->assertNotEmpty($this->eukles->tracked);
+
         // The thanks page renders and the order STAYS accepted afterwards.
         $this->actingAs($user)->get("/orders/{$order->id}/thanks")->assertStatus(200);
         $this->assertEquals(Order::STATE_ACCEPTED, $order->fresh()->state);

--- a/tests/Integration/FreeTicketPurchaseTest.php
+++ b/tests/Integration/FreeTicketPurchaseTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Integration;
+
+use App\Models\Order;
+use Tests\Integration\Concerns\CreatesEventFixtures;
+
+class FreeTicketPurchaseTest extends IntegrationTestCase
+{
+    use CreatesEventFixtures;
+
+    public function testFreeTicketPurchaseCompletesWithoutPayment()
+    {
+        $event = $this->createEvent($this->createOrganisation());
+        $category = $this->createTicketCategory($event, 0.0);
+        $user = $this->createUser();
+
+        $response = $this->actingAs($user)
+            ->post("/events/{$event->id}/register/{$category->id}/process");
+
+        $order = Order::query()->first();
+        $this->assertNotNull($order, 'An order should have been created');
+        $this->assertEquals(Order::STATE_ACCEPTED, $order->state);
+        $this->assertEquals($user->id, $order->user_id);
+        $response->assertRedirect(action('OrderController@thanks', [$order->id]));
+
+        // No payment API involved; confirmation email requested via the API.
+        $this->assertCount(0, $this->catlabApi->createOrderCalls);
+        $this->assertCount(1, $this->catlabApi->sendEmailCalls);
+
+        // The thanks page renders and the order STAYS accepted afterwards.
+        $this->actingAs($user)->get("/orders/{$order->id}/thanks")->assertStatus(200);
+        $this->assertEquals(Order::STATE_ACCEPTED, $order->fresh()->state);
+    }
+}

--- a/tests/Integration/HarnessTest.php
+++ b/tests/Integration/HarnessTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Tests\Integration;
+
+class HarnessTest extends IntegrationTestCase
+{
+    public function testRunsAgainstDedicatedTestDatabase()
+    {
+        $this->assertEquals('catlab_events_test', \DB::connection()->getDatabaseName());
+    }
+
+    public function testStatusEndpointResponds()
+    {
+        $this->get('/status')->assertStatus(200);
+    }
+}

--- a/tests/Integration/IntegrationTestCase.php
+++ b/tests/Integration/IntegrationTestCase.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Tests\Integration;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+abstract class IntegrationTestCase extends TestCase
+{
+    use RefreshDatabase;
+}

--- a/tests/Integration/IntegrationTestCase.php
+++ b/tests/Integration/IntegrationTestCase.php
@@ -2,10 +2,39 @@
 
 namespace Tests\Integration;
 
+use App\Services\CatLabApiClientFactory;
+use CatLab\Eukles\Client\Interfaces\EuklesClient as EuklesClientInterface;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Integration\Fakes\FakeCatLabApiClient;
+use Tests\Integration\Fakes\FakeCatLabApiClientFactory;
+use Tests\Integration\Fakes\FakeEuklesClient;
 use Tests\TestCase;
 
 abstract class IntegrationTestCase extends TestCase
 {
     use RefreshDatabase;
+
+    /**
+     * @var FakeCatLabApiClient
+     */
+    protected $catlabApi;
+
+    /**
+     * @var FakeEuklesClient
+     */
+    protected $eukles;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->catlabApi = new FakeCatLabApiClient();
+        $this->app->instance(
+            CatLabApiClientFactory::class,
+            new FakeCatLabApiClientFactory($this->catlabApi)
+        );
+
+        $this->eukles = new FakeEuklesClient();
+        $this->app->instance(EuklesClientInterface::class, $this->eukles);
+    }
 }

--- a/tests/Integration/PaidTicketPurchaseTest.php
+++ b/tests/Integration/PaidTicketPurchaseTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Integration;
+
+use App\Models\Order;
+use Tests\Integration\Concerns\CreatesEventFixtures;
+
+class PaidTicketPurchaseTest extends IntegrationTestCase
+{
+    use CreatesEventFixtures;
+
+    public function testPaidTicketPurchaseRedirectsToPaymentAndConfirmsViaCallback()
+    {
+        $event = $this->createEvent($this->createOrganisation());
+        $category = $this->createTicketCategory($event, 15.0);
+        $user = $this->createUser();
+
+        // Step 1: submit the order — should create a remote order and
+        // redirect the buyer to the payment page.
+        $response = $this->actingAs($user)
+            ->post("/events/{$event->id}/register/{$category->id}/process");
+
+        $order = Order::query()->first();
+        $this->assertNotNull($order, 'An order should have been created');
+        $this->assertEquals(Order::STATE_PENDING, $order->state);
+        $this->assertEquals($this->catlabApi->nextOrderId, $order->catlab_order_id);
+        $this->assertCount(1, $this->catlabApi->createOrderCalls);
+
+        $payload = $this->catlabApi->createOrderCalls[0];
+        $this->assertEquals($event->name, $payload['items'][0]['name']);
+
+        $response->assertStatus(302);
+        $this->assertStringStartsWith(
+            'https://pay.example.com/order/' . $this->catlabApi->nextOrderId,
+            $response->headers->get('Location')
+        );
+
+        // Step 2: the PSP reports payment — callback flips the order to
+        // accepted and triggers the confirmation email.
+        $this->catlabApi->orderStatus = 'ACCEPTED';
+        $this->get("/orders/{$order->id}/sync")->assertStatus(200);
+
+        $this->assertEquals(Order::STATE_ACCEPTED, $order->fresh()->state);
+        $this->assertCount(1, $this->catlabApi->sendEmailCalls);
+
+        // Step 3: the thanks page renders the confirmation.
+        $this->actingAs($user)->get("/orders/{$order->id}/thanks")->assertStatus(200);
+        $this->assertEquals(Order::STATE_ACCEPTED, $order->fresh()->state);
+    }
+}

--- a/tests/Integration/PaidTicketPurchaseTest.php
+++ b/tests/Integration/PaidTicketPurchaseTest.php
@@ -47,4 +47,27 @@ class PaidTicketPurchaseTest extends IntegrationTestCase
         $this->actingAs($user)->get("/orders/{$order->id}/thanks")->assertStatus(200);
         $this->assertEquals(Order::STATE_ACCEPTED, $order->fresh()->state);
     }
+
+    public function testSyncCallbackWorksUnauthenticated()
+    {
+        $event = $this->createEvent($this->createOrganisation());
+        $category = $this->createTicketCategory($event, 15.0);
+        $user = $this->createUser();
+
+        $this->actingAs($user)
+            ->post("/events/{$event->id}/register/{$category->id}/process");
+
+        $order = Order::query()->first();
+        $this->assertNotNull($order);
+
+        // The PSP calls the callback without any session — it must work
+        // for guests, or real payment confirmations break.
+        $this->app['auth']->guard()->logout();
+        $this->flushSession();
+
+        $this->catlabApi->orderStatus = 'ACCEPTED';
+        $this->get("/orders/{$order->id}/sync")->assertStatus(200);
+
+        $this->assertEquals(Order::STATE_ACCEPTED, $order->fresh()->state);
+    }
 }

--- a/tests/Integration/PurchaseGuardsTest.php
+++ b/tests/Integration/PurchaseGuardsTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Integration;
+
+use App\Models\Order;
+use Tests\Integration\Concerns\CreatesEventFixtures;
+
+class PurchaseGuardsTest extends IntegrationTestCase
+{
+    use CreatesEventFixtures;
+
+    public function testTicketRegistrationRequiresLogin()
+    {
+        $event = $this->createEvent($this->createOrganisation());
+        $category = $this->createTicketCategory($event, 10.0);
+
+        $this->get("/events/{$event->id}/register/{$category->id}")
+            ->assertRedirect('/login');
+    }
+
+    public function testProcessingAnOrderRequiresLogin()
+    {
+        $event = $this->createEvent($this->createOrganisation());
+        $category = $this->createTicketCategory($event, 10.0);
+
+        $this->post("/events/{$event->id}/register/{$category->id}/process")
+            ->assertRedirect('/login');
+
+        $this->assertEquals(0, Order::query()->count());
+    }
+}

--- a/tests/Integration/SmokeTest.php
+++ b/tests/Integration/SmokeTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Integration;
+
+use Tests\Integration\Concerns\CreatesEventFixtures;
+
+class SmokeTest extends IntegrationTestCase
+{
+    use CreatesEventFixtures;
+
+    public function testHomepageRenders()
+    {
+        // EventController@index redirects to /admin when no Organisation exists
+        // at all (Organisation::getRepresentedOrganisation() falls back to
+        // Organisation::first()); a fresh test database has none, so we need one.
+        $this->createOrganisation();
+
+        $this->get('/')->assertStatus(200);
+    }
+
+    public function testEventPageRenders()
+    {
+        $event = $this->createEvent($this->createOrganisation());
+        $this->createTicketCategory($event, 10.0);
+
+        $response = $this->get('/events/' . $event->id);
+
+        $response->assertStatus(200);
+        $response->assertSee($event->name);
+    }
+
+    public function testTicketSelectionPageRendersForGuests()
+    {
+        $event = $this->createEvent($this->createOrganisation());
+        $this->createTicketCategory($event, 10.0);
+
+        // Guests get the "log in to register" explanation page.
+        $this->get('/events/' . $event->id . '/register')->assertStatus(200);
+    }
+}

--- a/tests/Unit/Services/CatLabApiClientFactoryTest.php
+++ b/tests/Unit/Services/CatLabApiClientFactoryTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Services\CatLabApiClientFactory;
+use CatLab\Accounts\Client\ApiClient;
+use Tests\TestCase;
+
+class CatLabApiClientFactoryTest extends TestCase
+{
+    public function testCreatesApiClient()
+    {
+        $factory = $this->app->make(CatLabApiClientFactory::class);
+
+        $this->assertInstanceOf(ApiClient::class, $factory->forUser(null));
+    }
+
+    public function testContainerBindingCanBeSwapped()
+    {
+        $fake = new class extends CatLabApiClientFactory {
+        };
+        $this->app->instance(CatLabApiClientFactory::class, $fake);
+
+        $this->assertSame($fake, $this->app->make(CatLabApiClientFactory::class));
+    }
+}


### PR DESCRIPTION
## Summary

HTTP-level integration tests proving the public site renders and the full ticket purchase flow works — free and paid — against a real MySQL 8 database with every external service faked. Runs inside the docker-compose `webserver` container (production PHP) against a dedicated `catlab_events_test` database, so dev data is never touched and no local PHP/DB setup is needed:

    bin/integration-tests.sh

**Stacked on #49** (needs the PHP 8.5 image) — merge that first, then retarget/merge this.

## What's covered (10 tests)

- **Smoke**: homepage, event page, ticket-selection page render.
- **Free purchase**: select → process → order `ACCEPTED`, thanks page renders, confirmation email requested, no payment API involved, Eukles tracking fired (all via fakes).
- **Paid purchase**: order created remotely (faked), redirect to payUrl, PSP callback `orders/{id}/sync` flips the order to `ACCEPTED` — exercised both authenticated and **as a guest**, locking in the unauthenticated-callback contract real PSP calls depend on.
- **Guards**: register routes redirect guests to login; no order is created.
- `migrate:fresh` on a clean MySQL 8 every run — proves the migration chain end-to-end.

## Production changes (2, both deliberate)

1. **`CatLabApiClientFactory` seam** — the three direct `new ApiClient(...)` sites (EventController, Order, SendEmail) now resolve a factory from the container so tests can bind a fake. Behavior identical in production.
2. **Bug fix (found by these tests): free orders were cancelled by the thanks page.** `Order::synchronize()` cancelled *any* order lacking a `catlab_order_id`; free orders never get one, and the thanks page calls `synchronize()`. It now only cancels orders still `PENDING`. Side benefit: the unauthenticated `GET orders/{id}/sync` can no longer flip an accepted or refunded order to `CANCELLED` (which re-fired cancellation email + UitPAS cancel).

Also: `mockery/mockery` dev-dependency bumped 0.9 → ^1.6 (0.9 fatals under PHP 8.5 inside Laravel's `RefreshDatabase`; nothing in the repo uses the Mockery API directly).

## Deviations from the spec (documented)

- The plan's fixture code predated schema drift: `events.startDate/endDate` moved to the `event_dates` table (2021), `description`/`event_type` are NOT NULL, `requires_team` defaults true — the fixtures trait adapts, with comments.
- The free-flow test POSTs `/process` directly rather than walking select → confirm first; `confirmRegister` and the `PreparingOrder` event are not yet exercised.

## Known follow-ups (pre-existing, out of scope)

- `Order::synchronize()` compares `$this->status`, which is not a column (always null) — the "don't go cancelled → pending" guard is dead code.
- `Order::getEuklesAttributes()` does `$data['price']` on a null `getOrderData()` result for orders without a `catlab_order_id`.
- `Organisation::getRepresentedOrganisation()`'s function-static cache makes some smoke-test outcomes order-dependent within one phpunit process.
- docker-compose maps MySQL to host port 3312, which can collide with other local projects (tests are unaffected — they use the internal network).

## Verification

- `bin/integration-tests.sh`: OK (10 tests, 36 assertions)
- Host `vendor/bin/phpunit --testsuite Unit`: OK (9 tests) — still DB-free
- Whole-branch review + fix wave completed; per-task review on every commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013HqprN6hPwwHLXeCRbGdgo